### PR TITLE
Add API for Database Schema

### DIFF
--- a/src/main/java/com/epam/edp/demo/entity/CategoryManagers.java
+++ b/src/main/java/com/epam/edp/demo/entity/CategoryManagers.java
@@ -1,0 +1,17 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "CategoryManagers")
+public class CategoryManagers {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String email;
+    private String assortmentCategory;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ErrorLanguages2.java
+++ b/src/main/java/com/epam/edp/demo/entity/ErrorLanguages2.java
@@ -1,0 +1,16 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ErrorLanguages2")
+public class ErrorLanguages2 {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String name;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ErrorMessages1.java
+++ b/src/main/java/com/epam/edp/demo/entity/ErrorMessages1.java
@@ -1,0 +1,23 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ErrorMessages1", indexes = {
+        @Index(columnList = "errorCode", unique = true)
+})
+public class ErrorMessages1 {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "errorCode")
+    private Errors error;
+
+    private String english;
+    private String dutch;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ErrorMessages2.java
+++ b/src/main/java/com/epam/edp/demo/entity/ErrorMessages2.java
@@ -1,0 +1,24 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ErrorMessages2")
+public class ErrorMessages2 {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "errorCode")
+    private Errors error;
+
+    @ManyToOne
+    @JoinColumn(name = "languageId")
+    private ErrorLanguages2 language;
+
+    private String text;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ErrorMessages3.java
+++ b/src/main/java/com/epam/edp/demo/entity/ErrorMessages3.java
@@ -1,0 +1,25 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ErrorMessages3", indexes = {
+        @Index(columnList = "errorCode", unique = true)
+})
+public class ErrorMessages3 {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "errorCode")
+    private Errors error;
+
+    @Enumerated(EnumType.STRING)
+    private ErrorMessages3Language language;
+
+    private String text;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ErrorMessages3Language.java
+++ b/src/main/java/com/epam/edp/demo/entity/ErrorMessages3Language.java
@@ -1,0 +1,6 @@
+package com.epam.edp.demo.entity;
+
+public enum ErrorMessages3Language {
+    English,
+    Dutch
+}

--- a/src/main/java/com/epam/edp/demo/entity/ErrorReceiverType.java
+++ b/src/main/java/com/epam/edp/demo/entity/ErrorReceiverType.java
@@ -1,0 +1,6 @@
+package com.epam.edp.demo.entity;
+
+public enum ErrorReceiverType {
+    Supplier,
+    CAM
+}

--- a/src/main/java/com/epam/edp/demo/entity/Errors.java
+++ b/src/main/java/com/epam/edp/demo/entity/Errors.java
@@ -1,0 +1,22 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "Errors")
+public class Errors {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID code;
+
+    private String initialErrorMessage;
+    private String enrichedErrorMessageEnglish;
+    private String enrichedErrorMessageDutch;
+    private String attribute;
+
+    @Enumerated(EnumType.STRING)
+    private ErrorReceiverType receiverType;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/MainTypes.java
+++ b/src/main/java/com/epam/edp/demo/entity/MainTypes.java
@@ -1,0 +1,6 @@
+package com.epam.edp.demo.entity;
+
+public enum MainTypes {
+    Briefing,
+    DW
+}

--- a/src/main/java/com/epam/edp/demo/entity/ProductStatus.java
+++ b/src/main/java/com/epam/edp/demo/entity/ProductStatus.java
@@ -1,0 +1,6 @@
+package com.epam.edp.demo.entity;
+
+public enum ProductStatus {
+    Invalid,
+    Uploaded
+}

--- a/src/main/java/com/epam/edp/demo/entity/Products.java
+++ b/src/main/java/com/epam/edp/demo/entity/Products.java
@@ -1,0 +1,18 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "Products")
+public class Products {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private UUID supplierId;
+    private String assortmentGroup;
+    private String shortDescription;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ProjectMainType.java
+++ b/src/main/java/com/epam/edp/demo/entity/ProjectMainType.java
@@ -1,0 +1,6 @@
+package com.epam.edp.demo.entity;
+
+public enum ProjectMainType {
+    Briefing,
+    DW
+}

--- a/src/main/java/com/epam/edp/demo/entity/ProjectSubType.java
+++ b/src/main/java/com/epam/edp/demo/entity/ProjectSubType.java
@@ -1,0 +1,6 @@
+package com.epam.edp.demo.entity;
+
+public enum ProjectSubType {
+    Worp,
+    Mutatie
+}

--- a/src/main/java/com/epam/edp/demo/entity/Projects.java
+++ b/src/main/java/com/epam/edp/demo/entity/Projects.java
@@ -1,0 +1,28 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.util.UUID;
+
+@Entity
+@Table(name = "Projects")
+public class Projects {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID code;
+
+    private String fileName;
+
+    @Enumerated(EnumType.STRING)
+    private ProjectMainType mainType;
+
+    @Enumerated(EnumType.STRING)
+    private ProjectSubType subType;
+
+    private String assortmentCategory;
+    private Timestamp createdOn;
+    private Timestamp deadline;
+    private Timestamp inEffectFrom;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ProjectsProducts.java
+++ b/src/main/java/com/epam/edp/demo/entity/ProjectsProducts.java
@@ -1,0 +1,30 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.util.UUID;
+
+@Entity
+@Table(name = "Projects_Products", indexes = {
+        @Index(columnList = "projectId, productId", unique = true)
+})
+public class ProjectsProducts {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "projectId")
+    private Projects project;
+
+    @ManyToOne
+    @JoinColumn(name = "productId")
+    private Products product;
+
+    @Enumerated(EnumType.STRING)
+    private ProductStatus status;
+
+    private Timestamp updatedOn;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/SignalType.java
+++ b/src/main/java/com/epam/edp/demo/entity/SignalType.java
@@ -1,0 +1,11 @@
+package com.epam.edp.demo.entity;
+
+public enum SignalType {
+    S2,
+    S3,
+    S4,
+    S5,
+    S6,
+    S7,
+    S8
+}

--- a/src/main/java/com/epam/edp/demo/entity/Signals.java
+++ b/src/main/java/com/epam/edp/demo/entity/Signals.java
@@ -1,0 +1,27 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.util.UUID;
+
+@Entity
+@Table(name = "Signals")
+public class Signals {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "projectCode")
+    private Projects project;
+
+    private Timestamp deliveryTime;
+    private boolean delivered;
+
+    @Enumerated(EnumType.STRING)
+    private SignalType type;
+
+    private boolean invalid;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/SignalsConfig.java
+++ b/src/main/java/com/epam/edp/demo/entity/SignalsConfig.java
@@ -1,0 +1,22 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "SignalsConfig")
+public class SignalsConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    private SignalType signalType;
+
+    private int daysPriorToDeadline;
+    private String timeOfTheDay;
+    private int numberOfRetries;
+    private int retryInterval;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/SubTypes.java
+++ b/src/main/java/com/epam/edp/demo/entity/SubTypes.java
@@ -1,0 +1,19 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "SubTypes")
+public class SubTypes {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private MainTypes mainType;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/SubTypesSignalsConfig.java
+++ b/src/main/java/com/epam/edp/demo/entity/SubTypesSignalsConfig.java
@@ -1,0 +1,24 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "SubTypes_SignalsConfig", indexes = {
+        @Index(columnList = "subTypeId, signalsConfigId", unique = true)
+})
+public class SubTypesSignalsConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "subTypeId")
+    private SubTypes subType;
+
+    @ManyToOne
+    @JoinColumn(name = "signalsConfigId")
+    private SignalsConfig signalsConfig;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/SupplierUsers.java
+++ b/src/main/java/com/epam/edp/demo/entity/SupplierUsers.java
@@ -1,0 +1,17 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+@Table(name = "SupplierUsers")
+public class SupplierUsers {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    private UUID supplierId;
+    private String email;
+
+    // Getters and Setters
+}

--- a/src/main/java/com/epam/edp/demo/entity/ValidationsErrors.java
+++ b/src/main/java/com/epam/edp/demo/entity/ValidationsErrors.java
@@ -1,0 +1,35 @@
+package com.epam.edp.demo.entity;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ValidationsErrors", indexes = {
+        @Index(columnList = "projectCode, supplierId, productId, errorCode", unique = true)
+})
+public class ValidationsErrors {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "projectCode")
+    private Projects project;
+
+    private UUID supplierId;
+
+    @ManyToOne
+    @JoinColumn(name = "productId")
+    private Products product;
+
+    @ManyToOne
+    @JoinColumn(name = "errorCode")
+    private Errors error;
+
+    private String initialErrorMessage;
+    private Timestamp createdOn;
+    private Timestamp solvedOn;
+
+    // Getters and Setters
+}


### PR DESCRIPTION
This PR adds the API for the database schema defined in database_schema.sql. The following files have been created under src/main/java/com/epam/edp/demo/entity:

- SignalType.java
- SignalsConfig.java
- MainTypes.java
- SubTypes.java
- SubTypesSignalsConfig.java
- ProjectMainType.java
- ProjectSubType.java
- Projects.java
- ValidationsErrors.java
- ErrorReceiverType.java
- Errors.java
- Products.java
- ProductStatus.java
- ProjectsProducts.java
- CategoryManagers.java
- SupplierUsers.java
- Signals.java
- ErrorMessages1.java
- ErrorMessages2.java
- ErrorLanguages2.java
- ErrorMessages3Language.java
- ErrorMessages3.java

These files define the entity classes for the data model.