### PR TITLE
Generate SpringBoot controllers and repositories for entities

### DIFF
--- a/src/main/java/com/epam/edp/demo/controller/CategoryManagersController.java
+++ b/src/main/java/com/epam/edp/demo/controller/CategoryManagersController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.CategoryManagers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.CategoryManagersRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/category-managers")
+public class CategoryManagersController {
+
+    @Autowired
+    private CategoryManagersRepository repository;
+
+    @GetMapping
+    public List<CategoryManagers> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CategoryManagers> findById(@PathVariable UUID id) {
+        Optional<CategoryManagers> categoryManager = repository.findById(id);
+        return categoryManager.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public CategoryManagers save(@RequestBody CategoryManagers categoryManager) {
+        return repository.save(categoryManager);
+    }
+
+    @PutMapping
+    public CategoryManagers update(@RequestBody CategoryManagers categoryManager) {
+        return repository.save(categoryManager);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ErrorLanguages2Controller.java
+++ b/src/main/java/com/epam/edp/demo/controller/ErrorLanguages2Controller.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ErrorLanguages2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ErrorLanguages2Repository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/error-languages2")
+public class ErrorLanguages2Controller {
+
+    @Autowired
+    private ErrorLanguages2Repository repository;
+
+    @GetMapping
+    public List<ErrorLanguages2> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ErrorLanguages2> findById(@PathVariable UUID id) {
+        Optional<ErrorLanguages2> errorLanguage = repository.findById(id);
+        return errorLanguage.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ErrorLanguages2 save(@RequestBody ErrorLanguages2 errorLanguage) {
+        return repository.save(errorLanguage);
+    }
+
+    @PutMapping
+    public ErrorLanguages2 update(@RequestBody ErrorLanguages2 errorLanguage) {
+        return repository.save(errorLanguage);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ErrorMessages1Controller.java
+++ b/src/main/java/com/epam/edp/demo/controller/ErrorMessages1Controller.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ErrorMessages1;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ErrorMessages1Repository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/error-messages1")
+public class ErrorMessages1Controller {
+
+    @Autowired
+    private ErrorMessages1Repository repository;
+
+    @GetMapping
+    public List<ErrorMessages1> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{errorCode}")
+    public ResponseEntity<ErrorMessages1> findById(@PathVariable UUID errorCode) {
+        Optional<ErrorMessages1> errorMessage = repository.findById(errorCode);
+        return errorMessage.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ErrorMessages1 save(@RequestBody ErrorMessages1 errorMessage) {
+        return repository.save(errorMessage);
+    }
+
+    @PutMapping
+    public ErrorMessages1 update(@RequestBody ErrorMessages1 errorMessage) {
+        return repository.save(errorMessage);
+    }
+
+    @DeleteMapping("/{errorCode}")
+    public void deleteById(@PathVariable UUID errorCode) {
+        repository.deleteById(errorCode);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ErrorMessages2Controller.java
+++ b/src/main/java/com/epam/edp/demo/controller/ErrorMessages2Controller.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ErrorMessages2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ErrorMessages2Repository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/error-messages2")
+public class ErrorMessages2Controller {
+
+    @Autowired
+    private ErrorMessages2Repository repository;
+
+    @GetMapping
+    public List<ErrorMessages2> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ErrorMessages2> findById(@PathVariable UUID id) {
+        Optional<ErrorMessages2> errorMessage = repository.findById(id);
+        return errorMessage.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ErrorMessages2 save(@RequestBody ErrorMessages2 errorMessage) {
+        return repository.save(errorMessage);
+    }
+
+    @PutMapping
+    public ErrorMessages2 update(@RequestBody ErrorMessages2 errorMessage) {
+        return repository.save(errorMessage);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ErrorMessages3Controller.java
+++ b/src/main/java/com/epam/edp/demo/controller/ErrorMessages3Controller.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ErrorMessages3;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ErrorMessages3Repository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/error-messages3")
+public class ErrorMessages3Controller {
+
+    @Autowired
+    private ErrorMessages3Repository repository;
+
+    @GetMapping
+    public List<ErrorMessages3> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{errorCode}")
+    public ResponseEntity<ErrorMessages3> findById(@PathVariable UUID errorCode) {
+        Optional<ErrorMessages3> errorMessage = repository.findById(errorCode);
+        return errorMessage.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ErrorMessages3 save(@RequestBody ErrorMessages3 errorMessage) {
+        return repository.save(errorMessage);
+    }
+
+    @PutMapping
+    public ErrorMessages3 update(@RequestBody ErrorMessages3 errorMessage) {
+        return repository.save(errorMessage);
+    }
+
+    @DeleteMapping("/{errorCode}")
+    public void deleteById(@PathVariable UUID errorCode) {
+        repository.deleteById(errorCode);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ErrorReceiverTypeController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ErrorReceiverTypeController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ErrorReceiverType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ErrorReceiverTypeRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/error-receiver-type")
+public class ErrorReceiverTypeController {
+
+    @Autowired
+    private ErrorReceiverTypeRepository repository;
+
+    @GetMapping
+    public List<ErrorReceiverType> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ErrorReceiverType> findById(@PathVariable UUID id) {
+        Optional<ErrorReceiverType> errorReceiverType = repository.findById(id);
+        return errorReceiverType.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ErrorReceiverType save(@RequestBody ErrorReceiverType errorReceiverType) {
+        return repository.save(errorReceiverType);
+    }
+
+    @PutMapping
+    public ErrorReceiverType update(@RequestBody ErrorReceiverType errorReceiverType) {
+        return repository.save(errorReceiverType);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ErrorsController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ErrorsController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.Errors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ErrorsRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/errors")
+public class ErrorsController {
+
+    @Autowired
+    private ErrorsRepository repository;
+
+    @GetMapping
+    public List<Errors> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{code}")
+    public ResponseEntity<Errors> findById(@PathVariable UUID code) {
+        Optional<Errors> error = repository.findById(code);
+        return error.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Errors save(@RequestBody Errors error) {
+        return repository.save(error);
+    }
+
+    @PutMapping
+    public Errors update(@RequestBody Errors error) {
+        return repository.save(error);
+    }
+
+    @DeleteMapping("/{code}")
+    public void deleteById(@PathVariable UUID code) {
+        repository.deleteById(code);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/MainTypesController.java
+++ b/src/main/java/com/epam/edp/demo/controller/MainTypesController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.MainTypes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.MainTypesRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/main-types")
+public class MainTypesController {
+
+    @Autowired
+    private MainTypesRepository repository;
+
+    @GetMapping
+    public List<MainTypes> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MainTypes> findById(@PathVariable UUID id) {
+        Optional<MainTypes> mainType = repository.findById(id);
+        return mainType.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public MainTypes save(@RequestBody MainTypes mainType) {
+        return repository.save(mainType);
+    }
+
+    @PutMapping
+    public MainTypes update(@RequestBody MainTypes mainType) {
+        return repository.save(mainType);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ProductStatusController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ProductStatusController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ProductStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ProductStatusRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/product-status")
+public class ProductStatusController {
+
+    @Autowired
+    private ProductStatusRepository repository;
+
+    @GetMapping
+    public List<ProductStatus> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProductStatus> findById(@PathVariable UUID id) {
+        Optional<ProductStatus> productStatus = repository.findById(id);
+        return productStatus.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ProductStatus save(@RequestBody ProductStatus productStatus) {
+        return repository.save(productStatus);
+    }
+
+    @PutMapping
+    public ProductStatus update(@RequestBody ProductStatus productStatus) {
+        return repository.save(productStatus);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ProductsController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ProductsController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.Products;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ProductsRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/products")
+public class ProductsController {
+
+    @Autowired
+    private ProductsRepository repository;
+
+    @GetMapping
+    public List<Products> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Products> findById(@PathVariable UUID id) {
+        Optional<Products> product = repository.findById(id);
+        return product.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Products save(@RequestBody Products product) {
+        return repository.save(product);
+    }
+
+    @PutMapping
+    public Products update(@RequestBody Products product) {
+        return repository.save(product);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ProjectMainTypeController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ProjectMainTypeController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ProjectMainType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ProjectMainTypeRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/project-main-type")
+public class ProjectMainTypeController {
+
+    @Autowired
+    private ProjectMainTypeRepository repository;
+
+    @GetMapping
+    public List<ProjectMainType> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProjectMainType> findById(@PathVariable UUID id) {
+        Optional<ProjectMainType> projectMainType = repository.findById(id);
+        return projectMainType.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ProjectMainType save(@RequestBody ProjectMainType projectMainType) {
+        return repository.save(projectMainType);
+    }
+
+    @PutMapping
+    public ProjectMainType update(@RequestBody ProjectMainType projectMainType) {
+        return repository.save(projectMainType);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ProjectSubTypeController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ProjectSubTypeController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ProjectSubType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ProjectSubTypeRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/project-sub-type")
+public class ProjectSubTypeController {
+
+    @Autowired
+    private ProjectSubTypeRepository repository;
+
+    @GetMapping
+    public List<ProjectSubType> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProjectSubType> findById(@PathVariable UUID id) {
+        Optional<ProjectSubType> projectSubType = repository.findById(id);
+        return projectSubType.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ProjectSubType save(@RequestBody ProjectSubType projectSubType) {
+        return repository.save(projectSubType);
+    }
+
+    @PutMapping
+    public ProjectSubType update(@RequestBody ProjectSubType projectSubType) {
+        return repository.save(projectSubType);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ProjectsController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ProjectsController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.Projects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ProjectsRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectsController {
+
+    @Autowired
+    private ProjectsRepository repository;
+
+    @GetMapping
+    public List<Projects> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{code}")
+    public ResponseEntity<Projects> findById(@PathVariable UUID code) {
+        Optional<Projects> project = repository.findById(code);
+        return project.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Projects save(@RequestBody Projects project) {
+        return repository.save(project);
+    }
+
+    @PutMapping
+    public Projects update(@RequestBody Projects project) {
+        return repository.save(project);
+    }
+
+    @DeleteMapping("/{code}")
+    public void deleteById(@PathVariable UUID code) {
+        repository.deleteById(code);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ProjectsProductsController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ProjectsProductsController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ProjectsProducts;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ProjectsProductsRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/projects-products")
+public class ProjectsProductsController {
+
+    @Autowired
+    private ProjectsProductsRepository repository;
+
+    @GetMapping
+    public List<ProjectsProducts> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{projectId}/{productId}")
+    public ResponseEntity<ProjectsProducts> findById(@PathVariable UUID projectId, @PathVariable UUID productId) {
+        Optional<ProjectsProducts> projectsProducts = repository.findById(projectId, productId);
+        return projectsProducts.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ProjectsProducts save(@RequestBody ProjectsProducts projectsProducts) {
+        return repository.save(projectsProducts);
+    }
+
+    @PutMapping
+    public ProjectsProducts update(@RequestBody ProjectsProducts projectsProducts) {
+        return repository.save(projectsProducts);
+    }
+
+    @DeleteMapping("/{projectId}/{productId}")
+    public void deleteById(@PathVariable UUID projectId, @PathVariable UUID productId) {
+        repository.deleteById(projectId, productId);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/SignalTypeController.java
+++ b/src/main/java/com/epam/edp/demo/controller/SignalTypeController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.SignalType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.SignalTypeRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/signal-type")
+public class SignalTypeController {
+
+    @Autowired
+    private SignalTypeRepository repository;
+
+    @GetMapping
+    public List<SignalType> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SignalType> findById(@PathVariable UUID id) {
+        Optional<SignalType> signalType = repository.findById(id);
+        return signalType.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public SignalType save(@RequestBody SignalType signalType) {
+        return repository.save(signalType);
+    }
+
+    @PutMapping
+    public SignalType update(@RequestBody SignalType signalType) {
+        return repository.save(signalType);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/SignalsConfigController.java
+++ b/src/main/java/com/epam/edp/demo/controller/SignalsConfigController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.SignalsConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.SignalsConfigRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/signals-config")
+public class SignalsConfigController {
+
+    @Autowired
+    private SignalsConfigRepository repository;
+
+    @GetMapping
+    public List<SignalsConfig> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SignalsConfig> findById(@PathVariable UUID id) {
+        Optional<SignalsConfig> signalsConfig = repository.findById(id);
+        return signalsConfig.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public SignalsConfig save(@RequestBody SignalsConfig signalsConfig) {
+        return repository.save(signalsConfig);
+    }
+
+    @PutMapping
+    public SignalsConfig update(@RequestBody SignalsConfig signalsConfig) {
+        return repository.save(signalsConfig);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/SignalsController.java
+++ b/src/main/java/com/epam/edp/demo/controller/SignalsController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.Signals;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.SignalsRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/signals")
+public class SignalsController {
+
+    @Autowired
+    private SignalsRepository repository;
+
+    @GetMapping
+    public List<Signals> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Signals> findById(@PathVariable UUID id) {
+        Optional<Signals> signal = repository.findById(id);
+        return signal.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Signals save(@RequestBody Signals signal) {
+        return repository.save(signal);
+    }
+
+    @PutMapping
+    public Signals update(@RequestBody Signals signal) {
+        return repository.save(signal);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/SubTypesController.java
+++ b/src/main/java/com/epam/edp/demo/controller/SubTypesController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.SubTypes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.SubTypesRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/sub-types")
+public class SubTypesController {
+
+    @Autowired
+    private SubTypesRepository repository;
+
+    @GetMapping
+    public List<SubTypes> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SubTypes> findById(@PathVariable UUID id) {
+        Optional<SubTypes> subType = repository.findById(id);
+        return subType.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public SubTypes save(@RequestBody SubTypes subType) {
+        return repository.save(subType);
+    }
+
+    @PutMapping
+    public SubTypes update(@RequestBody SubTypes subType) {
+        return repository.save(subType);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/SubTypesSignalsConfigController.java
+++ b/src/main/java/com/epam/edp/demo/controller/SubTypesSignalsConfigController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.SubTypesSignalsConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.SubTypesSignalsConfigRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/sub-types-signals-config")
+public class SubTypesSignalsConfigController {
+
+    @Autowired
+    private SubTypesSignalsConfigRepository repository;
+
+    @GetMapping
+    public List<SubTypesSignalsConfig> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{subTypeId}/{signalsConfigId}")
+    public ResponseEntity<SubTypesSignalsConfig> findById(@PathVariable UUID subTypeId, @PathVariable UUID signalsConfigId) {
+        Optional<SubTypesSignalsConfig> subTypesSignalsConfig = repository.findById(subTypeId, signalsConfigId);
+        return subTypesSignalsConfig.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public SubTypesSignalsConfig save(@RequestBody SubTypesSignalsConfig subTypesSignalsConfig) {
+        return repository.save(subTypesSignalsConfig);
+    }
+
+    @PutMapping
+    public SubTypesSignalsConfig update(@RequestBody SubTypesSignalsConfig subTypesSignalsConfig) {
+        return repository.save(subTypesSignalsConfig);
+    }
+
+    @DeleteMapping("/{subTypeId}/{signalsConfigId}")
+    public void deleteById(@PathVariable UUID subTypeId, @PathVariable UUID signalsConfigId) {
+        repository.deleteById(subTypeId, signalsConfigId);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/SupplierUsersController.java
+++ b/src/main/java/com/epam/edp/demo/controller/SupplierUsersController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.SupplierUsers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.SupplierUsersRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/supplier-users")
+public class SupplierUsersController {
+
+    @Autowired
+    private SupplierUsersRepository repository;
+
+    @GetMapping
+    public List<SupplierUsers> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SupplierUsers> findById(@PathVariable UUID id) {
+        Optional<SupplierUsers> supplierUser = repository.findById(id);
+        return supplierUser.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public SupplierUsers save(@RequestBody SupplierUsers supplierUser) {
+        return repository.save(supplierUser);
+    }
+
+    @PutMapping
+    public SupplierUsers update(@RequestBody SupplierUsers supplierUser) {
+        return repository.save(supplierUser);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteById(@PathVariable UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/controller/ValidationsErrorsController.java
+++ b/src/main/java/com/epam/edp/demo/controller/ValidationsErrorsController.java
@@ -1,0 +1,43 @@
+package com.epam.edp.demo.controller;
+
+import com.epam.edp.demo.entity.ValidationsErrors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.epam.edp.demo.repository.ValidationsErrorsRepository;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/validations-errors")
+public class ValidationsErrorsController {
+
+    @Autowired
+    private ValidationsErrorsRepository repository;
+
+    @GetMapping
+    public List<ValidationsErrors> findAll() {
+        return repository.findAll();
+    }
+
+    @GetMapping("/{projectCode}/{supplierId}/{productId}/{errorCode}")
+    public ResponseEntity<ValidationsErrors> findById(@PathVariable UUID projectCode, @PathVariable UUID supplierId, @PathVariable UUID productId, @PathVariable UUID errorCode) {
+        Optional<ValidationsErrors> validationsErrors = repository.findById(projectCode, supplierId, productId, errorCode);
+        return validationsErrors.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ValidationsErrors save(@RequestBody ValidationsErrors validationsErrors) {
+        return repository.save(validationsErrors);
+    }
+
+    @PutMapping
+    public ValidationsErrors update(@RequestBody ValidationsErrors validationsErrors) {
+        return repository.save(validationsErrors);
+    }
+
+    @DeleteMapping("/{projectCode}/{supplierId}/{productId}/{errorCode}")
+    public void deleteById(@PathVariable UUID projectCode, @PathVariable UUID supplierId, @PathVariable UUID productId, @PathVariable UUID errorCode) {
+        repository.deleteById(projectCode, supplierId, productId, errorCode);
+    }
+}

--- a/src/main/java/com/epam/edp/demo/repository/CategoryManagersRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/CategoryManagersRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.CategoryManagers;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface CategoryManagersRepository extends JpaRepository<CategoryManagers, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ErrorLanguages2Repository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ErrorLanguages2Repository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ErrorLanguages2;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ErrorLanguages2Repository extends JpaRepository<ErrorLanguages2, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ErrorMessages1Repository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ErrorMessages1Repository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ErrorMessages1;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ErrorMessages1Repository extends JpaRepository<ErrorMessages1, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ErrorMessages2Repository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ErrorMessages2Repository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ErrorMessages2;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ErrorMessages2Repository extends JpaRepository<ErrorMessages2, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ErrorMessages3Repository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ErrorMessages3Repository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ErrorMessages3;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ErrorMessages3Repository extends JpaRepository<ErrorMessages3, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ErrorReceiverTypeRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ErrorReceiverTypeRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ErrorReceiverType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ErrorReceiverTypeRepository extends JpaRepository<ErrorReceiverType, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ErrorsRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ErrorsRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.Errors;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ErrorsRepository extends JpaRepository<Errors, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/MainTypesRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/MainTypesRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.MainTypes;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface MainTypesRepository extends JpaRepository<MainTypes, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ProductStatusRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ProductStatusRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ProductStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ProductStatusRepository extends JpaRepository<ProductStatus, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ProductsRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ProductsRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.Products;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ProductsRepository extends JpaRepository<Products, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ProjectMainTypeRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ProjectMainTypeRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ProjectMainType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ProjectMainTypeRepository extends JpaRepository<ProjectMainType, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ProjectSubTypeRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ProjectSubTypeRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ProjectSubType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ProjectSubTypeRepository extends JpaRepository<ProjectSubType, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ProjectsProductsRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ProjectsProductsRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ProjectsProducts;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ProjectsProductsRepository extends JpaRepository<ProjectsProducts, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ProjectsRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ProjectsRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.Projects;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ProjectsRepository extends JpaRepository<Projects, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/SignalTypeRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/SignalTypeRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.SignalType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface SignalTypeRepository extends JpaRepository<SignalType, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/SignalsConfigRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/SignalsConfigRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.SignalsConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface SignalsConfigRepository extends JpaRepository<SignalsConfig, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/SignalsRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/SignalsRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.Signals;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface SignalsRepository extends JpaRepository<Signals, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/SubTypesRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/SubTypesRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.SubTypes;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface SubTypesRepository extends JpaRepository<SubTypes, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/SubTypesSignalsConfigRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/SubTypesSignalsConfigRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.SubTypesSignalsConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface SubTypesSignalsConfigRepository extends JpaRepository<SubTypesSignalsConfig, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/SupplierUsersRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/SupplierUsersRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.SupplierUsers;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface SupplierUsersRepository extends JpaRepository<SupplierUsers, UUID> {
+}

--- a/src/main/java/com/epam/edp/demo/repository/ValidationsErrorsRepository.java
+++ b/src/main/java/com/epam/edp/demo/repository/ValidationsErrorsRepository.java
@@ -1,0 +1,10 @@
+package com.epam.edp.demo.repository;
+
+import com.epam.edp.demo.entity.ValidationsErrors;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+@Repository
+public interface ValidationsErrorsRepository extends JpaRepository<ValidationsErrors, UUID> {
+}


### PR DESCRIPTION
This pull request includes the creation of Spring Boot controllers and repositories for the entities present in the `src/main/java/com/epam/edp/demo/entity` folder. The generated controllers provide basic CRUD operations for each entity.